### PR TITLE
Long [code][/code] tags and other content could break out of the

### DIFF
--- a/core/skins/Wilderless/extra.css
+++ b/core/skins/Wilderless/extra.css
@@ -87,7 +87,6 @@ body #sidebar .column
 
 .postarea
 	display: block
-	width: auto // mostly for IE6
 	margin-left: 0
 
 @remove .postarea

--- a/core/skins/Wireless/extra.css
+++ b/core/skins/Wireless/extra.css
@@ -50,7 +50,6 @@ body #sidebar .column
 
 .postarea
 	display: block
-	width: auto // mostly for IE6
 	margin-left: 0
 
 @remove .postarea

--- a/core/skins/sections.css
+++ b/core/skins/sections.css
@@ -428,6 +428,7 @@ hr.sep
 		background: #e799a3
 
 .postarea
+	width: 75%
 	padding: 0 15px
 	@if $can_flex
 		display: flex

--- a/core/skins/sections.css
+++ b/core/skins/sections.css
@@ -428,7 +428,7 @@ hr.sep
 		background: #e799a3
 
 .postarea
-	width: 75%
+	width: 0
 	padding: 0 15px
 	@if $can_flex
 		display: flex


### PR DESCRIPTION
postarea div. Fixed with setting width of .posteare to 75%.