### PR TITLE
Fix low spam/flood limits

### DIFF
--- a/core/app/Subs.php
+++ b/core/app/Subs.php
@@ -1417,13 +1417,13 @@ function spamProtection($error_type)
 		'sendtopc' => $settings['spamWaitTime'] * 4,
 		'sendmail' => $settings['spamWaitTime'] * 5,
 		'report' => $settings['spamWaitTime'] * 4,
-		'search' => !empty($settings['search_floodcontrol_time']) ? $settings['search_floodcontrol_time'] : 1,
+		'search' => isset($settings['search_floodcontrol_time']) ? $settings['search_floodcontrol_time'] : 1,
 	);
 
+	$timeLimit = isset($timeOverrides[$error_type]) ? $timeOverrides[$error_type] : $settings['spamWaitTime'];
+
 	// Moderators are free...
-	if (!allowedTo('moderate_board'))
-		$timeLimit = isset($timeOverrides[$error_type]) ? $timeOverrides[$error_type] : $settings['spamWaitTime'];
-	else
+	if (allowedTo('moderate_board') && $timeLimit > 2)
 		$timeLimit = 2;
 
 	// Delete old entries...


### PR DESCRIPTION
spamProtection() did not handle search limits correct.
It was not possible to disable flood control for search,
lowest possible value was 1. The new check also allows
a value of 0.
If user has moderator permissions, the limit was
always overridden with 2. We now check if the limit is
greater than 2 and if not, we override it with 2.