### PR TITLE
Optimize spamProtection if it's disabled

### DIFF
--- a/core/app/Subs.php
+++ b/core/app/Subs.php
@@ -1426,6 +1426,10 @@ function spamProtection($error_type)
 	if (allowedTo('moderate_board') && $timeLimit > 2)
 		$timeLimit = 2;
 
+	// Flood control is disabled, so don't waste time
+	if($timeLimit == 0)
+		return false;
+
 	// Delete old entries...
 	wesql::query('
 		DELETE FROM {db_prefix}log_floodcontrol


### PR DESCRIPTION
If spamProtection is disabled (timeLimit == 0) than we don't need to
perform log queries. Should make things a little bit faster also we
don't get an error anymore, that the last request was 0 seconds ago.