### PR TITLE
Login looks bad on small screens

### DIFF
--- a/core/skins/sections.css
+++ b/core/skins/sections.css
@@ -714,23 +714,33 @@ input.modify extends .edit_button
 	.login
 		margin: auto
 		dl
-			overflow: auto
-			clear: right
+			overflow: none
+			clear: right !important
 		dt, dd
 			margin: 0 0 .4em
-			width: 44%
+			width: 44% !important
 			padding: .1em
 		dt
 			float: left
-			clear: both
+			clear: both !important
 			text-align: right
 			font-weight: 700
 		dd
-			width: 54%
+			width: 54% !important
 			float: right
 			text-align: left
+			padding-left: 0px !important
+			clear: none !important
 		p
 			text-align: center
+		input
+			max-width: 100%
+
+	@media (max-width: 450px)
+		.login
+			dt, dd
+				float, text-align: left
+				width: 100% !important				
 
 	#login #main
 		vertical-align: middle


### PR DESCRIPTION
- Some .login rules got overwritten on screens
  smaller than 600px. Added !important flag to
  them.
- Besides that the overflow rule looked
  bad.
- And the password input missed the max-width
  rule.
- On very small screens (<= 450px) we now
  break lines between dt and dd