### PR TITLE
.posthead didn't do well with long topic names

### DIFF
--- a/core/skins/sections.css
+++ b/core/skins/sections.css
@@ -152,8 +152,7 @@ section.ic
 		div mixes .inline-block
 	@elseif $can_flex
 		display: flex
-		flex-wrap: wrap
-		align-items: center
+		align-items: stretch
 		> div
 			flex: 1 1 auto
 	@else
@@ -169,6 +168,10 @@ section.ic
 	text-align: center
 	color: gray
 	letter-spacing: -1px
+	width: 60%
+
+#top_subject, .prevnext_prev
+	word-wrap: break-word
 
 // Previous/next topic links inside .posthead
 .prevnext_prev


### PR DESCRIPTION
.posthead
- removed flex-wrap: wrap looks bad and doesn't affect us
- align-items:center => stretch. We want it to align to top

top_subject
- set width to 60%

top_subject & prevnext_prev
- add word-wrap: break-word