### PR TITLE
Allow setting the max length a subject should have.

### DIFF
--- a/core/app/ManagePosts.php
+++ b/core/app/ManagePosts.php
@@ -207,6 +207,7 @@ function ModifyPostSettings($return_config = false)
 			array('check', 'additional_options_collapsable'),
 		'',
 			// Posting limits...
+			array('int', 'max_subjectLength', 'subtext' => $txt['max_subjectLength_zero'], 'postinput' => $txt['manageposts_characters']),
 			array('int', 'max_messageLength', 'subtext' => $txt['max_messageLength_zero'], 'postinput' => $txt['manageposts_characters']),
 			array('int', 'topicSummaryPosts', 'postinput' => $txt['manageposts_posts']),
 		'',

--- a/core/app/Post.php
+++ b/core/app/Post.php
@@ -353,8 +353,10 @@ function Post($post_errors = array())
 		$form_message = westr::htmlspecialchars($_REQUEST['message'], ENT_QUOTES);
 
 		// Make sure the subject isn't too long - taking into account special characters.
-		if (westr::strlen($form_subject) > 100)
-			$form_subject = westr::substr($form_subject, 0, 100);
+		$len_form_subject = westr::strlen($form_subject);
+        $max_subject_length = !empty($settings['max_subjectLength']) ? $settings['max_subjectLength'] : 80;
+		if ($len_form_subject > $max_subject_length)
+            $post_errors[] = ['subject_too_long', [$max_subject_length, $len_form_subject]];
 
 		// Have we inadvertently trimmed off the subject of useful information?
 		if (!in_array('no_subject', $post_errors) && westr::htmltrim($form_subject) === '')
@@ -364,7 +366,6 @@ function Post($post_errors = array())
 		if (!empty($post_errors))
 		{
 			loadLanguage('Errors');
-
 			foreach ($post_errors as $error)
 			{
 				if (is_array($error))
@@ -372,7 +373,7 @@ function Post($post_errors = array())
 					$error_id = $error[0];
 					// Not really used, but we'll still set that.
 					$context['post_error'][$error_id] = true;
-					$context['post_error']['messages'][] = sprintf($txt['error_' . $error_id], $error[1]);
+					$context['post_error']['messages'][] = vsprintf($txt['error_' . $error_id], $error[1]);
 				}
 				else
 				{

--- a/core/app/Post2.php
+++ b/core/app/Post2.php
@@ -410,8 +410,14 @@ function Post2()
 	$_POST['subject'] = isset($_POST['subject']) ? westr::htmlspecialchars($_POST['subject'], ENT_QUOTES) : '';
 	$_POST['message'] = isset($_POST['message']) ? westr::htmlspecialchars($_POST['message'], ENT_QUOTES) : '';
 
+    // At this point, we want to make sure the subject isn't too long.
+    $len_form_subject = westr::strlen($form_subject);
+    $max_subject_length = !empty($settings['max_subjectLength']) ? $settings['max_subjectLength'] : 80;
 	if (westr::htmltrim($_POST['subject']) === '')
 		$post_errors[] = 'no_subject';
+    elseif ($len_form_subject > $max_subject_length)
+        $post_errors[] = ['subject_too_long', [$max_subject_length, $len_form_subject]];
+
 	if (westr::htmltrim($_POST['message']) === '')
 		$post_errors[] = 'no_message';
 	elseif (!empty($settings['max_messageLength']) && westr::strlen($_POST['message']) > $settings['max_messageLength'])
@@ -574,10 +580,6 @@ function Post2()
 	$_POST['subject'] = strtr($_POST['subject'], array("\r" => '', "\n" => '', "\t" => ''));
 	$_POST['guestname'] = htmlspecialchars($_POST['guestname']);
 	$_POST['email'] = htmlspecialchars($_POST['email']);
-
-	// At this point, we want to make sure the subject isn't too long.
-	if (westr::strlen($_POST['subject']) > 100)
-		$_POST['subject'] = westr::substr($_POST['subject'], 0, 100);
 
 	// Make the poll...
 	if (isset($_REQUEST['poll']))

--- a/core/html/Post.template.php
+++ b/core/html/Post.template.php
@@ -355,7 +355,7 @@ function template_post_header_before()
 
 function template_post_subject()
 {
-	global $context, $txt;
+	global $context, $txt, $settings;
 
 	// Now show the subject box for this post.
 	echo '
@@ -381,7 +381,7 @@ function template_post_subject()
 	echo '
 						</div>
 						<div>
-							<input name="subject" id="subject"', $context['subject'] == '' ? '' : ' value="' . $context['subject'] . '"', ' tabindex="', $context['tabindex']++, '" maxlength="80" class="w100">
+							<input name="subject" id="subject"', $context['subject'] == '' ? '' : ' value="' . $context['subject'] . '"', ' tabindex="', $context['tabindex']++, '" maxlength="', isset($settings['max_subjectLength']) ? ($settings['max_subjectLength'] == 0 ? -1 : $settings['max_subjectLength']) : 80 ,'" class="w100">
 						</div>
 					</div>';
 }

--- a/core/languages/Errors.english.php
+++ b/core/languages/Errors.english.php
@@ -219,7 +219,7 @@ $txt['error_need_verification_code'] = 'Please enter the verification code below
 $txt['error_bad_file'] = 'Sorry but the file specified could not be opened: %1$s';
 $txt['error_bad_line'] = 'The line you specified is invalid.';
 $txt['error_too_quickly'] = 'You completed the registration form too quickly, faster than would normally be possible.<br><br><div class="smalltext">(Hey, we don\'t take kindly to robots in here!)</div>';
-$txt['error_subject_too_long'] = 'Subject is too long. Max length is %d but your Subject is %d chars long.';
+$txt['error_subject_too_long'] = 'Subject is too long. Max length is %d but your subject is %d chars long.';
 
 $txt['smiley_not_found'] = 'Smiley not found.';
 $txt['smiley_has_no_code'] = 'No code for this smiley was given.';

--- a/core/languages/Errors.english.php
+++ b/core/languages/Errors.english.php
@@ -219,6 +219,7 @@ $txt['error_need_verification_code'] = 'Please enter the verification code below
 $txt['error_bad_file'] = 'Sorry but the file specified could not be opened: %1$s';
 $txt['error_bad_line'] = 'The line you specified is invalid.';
 $txt['error_too_quickly'] = 'You completed the registration form too quickly, faster than would normally be possible.<br><br><div class="smalltext">(Hey, we don\'t take kindly to robots in here!)</div>';
+$txt['error_subject_too_long'] = 'Subject is too long. Max length is %d but your Subject is %d chars long.';
 
 $txt['smiley_not_found'] = 'Smiley not found.';
 $txt['smiley_has_no_code'] = 'No code for this smiley was given.';

--- a/core/languages/ManagePosts.english.php
+++ b/core/languages/ManagePosts.english.php
@@ -7,6 +7,8 @@ $txt['enableEmbeddedFlash'] = 'Allow Flash embedding in posts';
 $txt['enableEmbeddedFlash_warning'] = 'May be a security risk!';
 $txt['additional_options_collapsable'] = 'Enable collapsible additional post options';
 
+$txt['max_subjectLength'] = 'Maximum allowed subject size';
+$txt['max_subjectLength_zero'] = '0 for no max. Attention: for values > 255 you have to alter the messages table.';
 $txt['max_messageLength'] = 'Maximum allowed post size';
 $txt['max_messageLength_zero'] = '0 for no max.';
 $txt['topicSummaryPosts'] = 'Posts to show on topic summary';


### PR DESCRIPTION
If subject is too long, yield an error.
+ Introduced $settings['max_subjectLength'].
+ Introduced $txt['error_subject_too_long'] in Errors.english.php
+ Introduced $txt['max_subjectLength'] and $txt['max_subjectLength_zero']
  in ManagePosts.english.php
+ Also using vsprintf for errors now to support more than one argument.
+ Before the limit for subject size was inconsistent. For editor it was
  80, for Post/Post2.php it was 100. We now use the same limit for all.
(ManagePosts.php, Post.php, Post2.php, Post.template.php, Errors.english.php, ManagePosts.english.php)