### PR TITLE
Changing password hashing algorithm from sha1

### DIFF
--- a/core/app/Subs-Members.php
+++ b/core/app/Subs-Members.php
@@ -608,7 +608,7 @@ function registerMember(&$regOptions, $return_errors = false)
 	$regOptions['register_vars'] = array(
 		'member_name' => $regOptions['username'],
 		'email_address' => $regOptions['email'],
-		'passwd' => sha1(strtolower($regOptions['username']) . $regOptions['password']),
+		'passwd' => password_hash($regOptions['password'], PASSWORD_DEFAULT, ['costs' => 10]),
 		'password_salt' => substr(md5(mt_rand()), 0, 4),
 		'posts' => 0,
 		'date_registered' => time(),

--- a/core/html/Login.template.php
+++ b/core/html/Login.template.php
@@ -12,11 +12,8 @@ function template_login()
 {
 	global $context, $settings, $txt;
 
-	if (empty($context['disable_login_hashing']))
-		$context['main_js_files']['sha1.js'] = true;
-
 	echo '
-		<form action="<URL>?action=login2" name="frmLogin" id="frmLogin" method="post" accept-charset="UTF-8" ', empty($context['disable_login_hashing']) ? ' onsubmit="hashLoginPassword(this, \'' . $context['session_id'] . '\');"' : '', '>
+		<form action="<URL>?action=login2" name="frmLogin" id="frmLogin" method="post" accept-charset="UTF-8">
 		<div class="login">
 			<we:cat>
 				<img src="', ASSETS, '/icons/online.gif">
@@ -59,7 +56,6 @@ function template_login()
 				</dl>
 				<p><input type="submit" value="', $txt['login'], '" class="submit"></p>
 				<p class="smalltext"><a href="<URL>?action=reminder">', $txt['forgot_your_password'], '</a></p>
-				<input type="hidden" name="hash_passwrd" value="">
 			</div>
 		</div></form>';
 
@@ -73,12 +69,8 @@ function template_kick_guest()
 {
 	global $context, $settings, $txt;
 
-	// This isn't that much... just like normal login but with a message at the top.
-	if (empty($context['disable_login_hashing']))
-		$context['main_js_files']['sha1.js'] = true;
-
 	echo '
-	<form action="<URL>?action=login2" method="post" accept-charset="UTF-8" name="frmLogin" id="frmLogin"', empty($context['disable_login_hashing']) ? ' onsubmit="hashLoginPassword(this, \'' . $context['session_id'] . '\');"' : '', '>
+	<form action="<URL>?action=login2" method="post" accept-charset="UTF-8" name="frmLogin" id="frmLogin">
 		<div class="login">
 			<we:cat>
 				', $txt['warning'], '
@@ -125,14 +117,10 @@ function template_maintenance()
 {
 	global $context, $txt, $settings;
 
-	// Display the administrator's message at the top.
-	if (empty($context['disable_login_hashing']))
-		$context['main_js_files']['sha1.js'] = true;
-
 	add_css_file('pages'); // #maintenance_mode
 
 	echo '
-<form action="<URL>?action=login2" method="post" accept-charset="UTF-8"', empty($context['disable_login_hashing']) ? ' onsubmit="hashLoginPassword(this, \'' . $context['session_id'] . '\');"' : '', '>
+<form action="<URL>?action=login2" method="post" accept-charset="UTF-8">
 	<div class="login" id="maintenance_mode">
 		<we:cat>
 			', $context['title'], '


### PR DESCRIPTION
to bcrypt using the password_hash() function.
We now transfer the password in plain from client
to server, before we sha1 hashed it. So make sure
you have ssl activated for wedge.
I completely rewrote the login authentication, the
old code was full of compatibilty stuff which is not
needed anymore in my opinion. Login stuff should be
as short and simple as possible to make sure it's
not buggy.
This is still WIP, currently you have to change the
{db_prefix}members passwrd column to VARCHAR(255) to
make this work properly.